### PR TITLE
Add a configurable SSL port for the proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ By default, `hotel` uses the following configuration values:
 ```js
 {
   "port": 2000,
+  "sslPort": 2001,
   "host": '127.0.0.1',
   
   // Timeout when proxying requests to local domains

--- a/src/conf.js
+++ b/src/conf.js
@@ -8,6 +8,7 @@ mkdirp.sync(hotelDir)
 // Defaults
 const defaults = {
   port: 2000,
+  sslPort: 2001,
   host: '127.0.0.1',
   timeout: 5000,
   tld: 'localhost',

--- a/src/daemon/group.js
+++ b/src/daemon/group.js
@@ -389,7 +389,7 @@ class Group extends EventEmitter {
       // If https make socket go through https proxy on 2001
       // TODO find a way to detect https and wss without relying on port number
       if (port === '443') {
-        return tcpProxy.proxy(socket, daemonConf.port + 1, hostname)
+        return tcpProxy.proxy(socket, daemonConf.sslPort, hostname)
       }
 
       const item = this.find(id)

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -48,5 +48,5 @@ app.listen(conf.port, conf.host, function() {
 })
 
 proxy.on('error', function(e) {
-  log('error', e);
-});
+  log('error', e)
+})

--- a/src/daemon/index.js
+++ b/src/daemon/index.js
@@ -41,7 +41,7 @@ const proxy = httpProxy.createServer({
 })
 
 // Start HTTPS proxy and HTTP server
-proxy.listen(conf.port + 1)
+proxy.listen(conf.sslPort)
 
 app.listen(conf.port, conf.host, function() {
   log(`Server listening on port ${conf.host}:${conf.port}`)

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,12 +1,13 @@
 const merge = require('webpack-merge')
 const common = require('./webpack.common.js')
+const conf = require('./src/conf')
 
 module.exports = merge(common, {
   devtool: 'inline-source-map',
   devServer: {
     contentBase: './dist',
     proxy: {
-      '/_': 'http://localhost:2000'
+      '/_': `http://localhost:${conf.port}`
     }
   }
 })


### PR DESCRIPTION
This will allow us to run hotel directly on port 80 and 443. Combined with the wildcard DNS for envoy.dev resolving to 127.0.0.1, we can eliminate the need for the automated proxy setting. This also allows other applications to route correctly even if they don't support http proxies out of the box, e.g. node apps.